### PR TITLE
fix: forbid interface name prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
   rules: {
     ...commonRules,
     'await-promise': true,
+    'interface-name': [true, 'never-prefix'],
     'no-any': true,
     'no-floating-promises': true,
     'no-inferrable-types': false,


### PR DESCRIPTION
BREAKING CHANGE: requires interface names to not
have uppercase "I" prefix