### PR TITLE
Fix: import with explicit side-effect triggered when importing CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const commonRules = {
   'no-dynamic-delete': true,
   'no-empty': false,
   'no-implicit-dependencies': [true, 'dev'],
-  'no-import-side-effect': true,
+  'no-import-side-effect': [true, {"ignore-module": "\\.css$"}],
   'no-invalid-template-strings': true,
   'no-invalid-this': true,
   'no-magic-numbers': true,


### PR DESCRIPTION
This change stops importing `.css` files into a module triggering the `import with explicit side-effect` error.